### PR TITLE
Removes Theme Editor link from WP Dashboard

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -11,3 +11,10 @@ function imprezachild_enqueue_styles()
         wp_get_theme()->get('Version') // this only works if you have Version in the style header
     );
 }
+
+/* Remove Menu Pages from Dashboard */
+add_action('admin_menu', 'imprezachild_remove_menus', 110);
+function imprezachild_remove_menus()
+{
+    remove_submenu_page('themes.php', 'theme-editor.php'); // Theme Editor
+}


### PR DESCRIPTION
This change will remove the Theme Editor link from the WP backend to prevent untracked file changes.