### PR TITLE
Fix footer headings and social icon positioning

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,9 +14,9 @@ Text Domain: imprezachild
 #           Table of Contents           #
 #  ######################################
 
-1. Utility Classes
-
-
+- Utility Classes
+- Site Header
+- Site Footer
 
 
 
@@ -26,4 +26,20 @@ Text Domain: imprezachild
 
 .margin-bottom-0 {
     margin-bottom: 0;
+}
+
+/* ###################################### 
+#              Site Header              #
+#  #####################################*/
+
+/* ###################################### 
+#              Site Footer              #
+#  #####################################*/
+
+.l-footer h2 {
+    font-size: 2.25em;
+}
+
+.l-footer .uvc-heading-spacer {
+    margin: 15px 0 30px;
 }

--- a/style.css
+++ b/style.css
@@ -43,3 +43,12 @@ Text Domain: imprezachild
 .l-footer .uvc-heading-spacer {
     margin: 15px 0 30px;
 }
+
+.l-footer .w-socials-list {
+    margin-left: 1.5rem;
+    margin-top: 20px;
+}
+
+.l-footer .w-socials-item-link:after {
+    font-size: 24px;
+}


### PR DESCRIPTION
Reduced H2 font size of headings in footer, increased white space around header separator lines and set the size/positioning the social icons.